### PR TITLE
[SN-606] get shipping directly from price objects instead of /shippingprices endpoint

### DIFF
--- a/src/components/Browse/catalog.js
+++ b/src/components/Browse/catalog.js
@@ -30,7 +30,11 @@ export default function Catalog({ search_query }) {
     }
 
     async function fetchMore() {
-        const request = createRequestObject('browse', {search: search_query, page: page+1})
+        const request = createRequestObject('browse', {
+            search: search_query,
+            page: page+1
+        })
+        
         const response = await fetch(request.url, request.headers)
         let results = await response.json()
         results = await convertCurrency(results)

--- a/src/components/Home/Carousels/carouselCard.js
+++ b/src/components/Home/Carousels/carouselCard.js
@@ -32,7 +32,8 @@ export default function CarouselCard({ data, index, type, length }) {
             modelName: data.model,
             price: data.price,
             image: data.image,
-            url: data.url
+            url: data.url,
+            shipping: data.shipping
         }
 
         dispatch(updateItemInfo(itemInfo))

--- a/src/components/Item/itemCard.js
+++ b/src/components/Item/itemCard.js
@@ -33,7 +33,8 @@ export default function ItemCard({ data }) {
             modelName: data.model,
             price: data.price,
             image: data.image,
-            url: data.url
+            url: data.url,
+            shipping: data.shipping
         }
 
         dispatch(updateItemInfo(itemInfo))

--- a/src/hooks/createRequest.js
+++ b/src/hooks/createRequest.js
@@ -17,83 +17,49 @@ export default function createRequestObject(type, filter) {
 			}
 		case 'stockx':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					"source": "stockx",
-					"search": filter.search,
-					"size": filter.size,
-					"gender": filter.gender
-				}),
+				url: `${api}/itemprices?source=stockx&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
 		case 'ebay':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					'source': 'ebay',
-					'search': filter.search,
-					'size': filter.size,
-					'ship_to': filter.shipTo,
-					'postal_code': filter.postalCode ? filter.postalCode : null
-				}),
+				url: `${api}/itemprices?source=ebay&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
 		case 'klekt':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					"source": "klekt",
-					"search": filter.search,
-					"size": filter.size
-				}),
+				url: `${api}/itemprices?source=klekt&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
 		case 'goat':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					"source": "goat",
-					"search": filter.search,
-					"size": filter.size
-				}),
+				url: `${api}/itemprices?source=goat&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
 		case 'flightclub':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					"source": "flightclub",
-					"search": filter.search,
-					"size": filter.size
-				}),
+				url: `${api}/itemprices?source=flightclub&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
-		case 'depopListings':
+		case 'depop':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					'source': 'depop',
-					'search': filter.search,
-					'size': filter.size,
-					'gender': filter.gender,
-					'ship_to': filter.shipTo
-				}),
+				url: `${api}/itemprices?source=depop&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
 			}
-		case 'grailedListings':
+		case 'grailed':
 			return {
-				url: `${api}/itemprices?` + new URLSearchParams({
-					"source": "grailed",
-					"search": filter.search,
-					"size": filter.size,
-					"ship_to": filter.country
-				}),
+				url: `${api}/itemprices?source=grailed&` + new URLSearchParams(filter),
 				headers: {
 					method: 'GET'
 				}
@@ -114,15 +80,6 @@ export default function createRequestObject(type, filter) {
 						"hitsPerPage": 15, 
 						"page": 0
 					})
-				}
-			}
-		case 'shippingPrices':
-			return {
-				url: `${api}/shippingprices2?` + new URLSearchParams({
-					'country': filter.country
-				}),
-				headers: {
-					method: 'GET'
 				}
 			}
 

--- a/src/hooks/scrapers.js
+++ b/src/hooks/scrapers.js
@@ -1,23 +1,40 @@
 import createRequestObject from './createRequest'
 
-/********** Lowest Prices **********/
 
-export async function stockxLowestPrice(item, currencyRate) {
+async function currencyConversionRate(from, to) {
+	const url = `https://hdwj2rvqkb.us-west-2.awsapprunner.com/currencyrate2?from_curr=${from}&to_curr=${to}`
+	const response = await fetch(url)
+	return await response.json()
+}
+
+
+export async function stockxLowestPrice(item, filter) {
 	if (!item.hasPrice) return []
-	
+
+	// TODO: move shipping currency conversion logic to backend
+	const shippingInfo = item.shipping
+	const shippingConversionRate = await currencyConversionRate(shippingInfo['currency'], filter.currency)
+	let shippingPrice = shippingInfo['cost'] * shippingConversionRate
+
 	return [{
 		source: 'stockx',
-		price: Math.round(item.price * currencyRate),
-		url: new URL(item.url)
+		price: Math.round(item.price * filter.usdRate),
+		url: new URL(item.url),
+		shippingPrice: shippingPrice
 	}]
 }
 
 
-export async function ebayLowestPrice(item, size, country, postalCode, currencyRate, currency) {
+export async function ebayLowestPrice(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.modelName.replace('(W)', '').concat(' ', item.skuId)
-	let request = createRequestObject('ebay', {search: search, size: size, shipTo: country, postalCode: postalCode})
+	let request = createRequestObject('ebay', {
+		search: search, 
+		size: filter.size, 
+		ship_to: filter.country, 
+		postal_code: filter.postalCode
+	})
 	
 	try {
 		const response = await fetch(request.url, request.headers)
@@ -29,15 +46,16 @@ export async function ebayLowestPrice(item, size, country, postalCode, currencyR
 		// TODO: move shipping currency conversion logic to backend
 		let shipping = null
 		if (itemData[0]['shipping']) {
-			if (currency !== itemData[0]['shipping']['@currencyId']) 
-				shipping = Math.round(itemData[0]['shipping']['__value__'] * currencyRate)
-			else 
+			// TODO: use real currency rate instead of usdRate
+			if (filter.currency !== itemData[0]['shipping']['@currencyId']) 
+				shipping = Math.round(itemData[0]['shipping']['__value__'] * filter.usdRate)
+			else
 				shipping = Math.round(itemData[0]['shipping']['__value__'])
 		}
 
 		return [{
 			source: 'ebay',
-			price: Math.round(itemData[0]['price'] * currencyRate),
+			price: Math.round(itemData[0]['price'] * filter.usdRate),
 			url: new URL(itemData[0]['url']),
 			shippingPrice: shipping
 		}]
@@ -47,22 +65,32 @@ export async function ebayLowestPrice(item, size, country, postalCode, currencyR
 }
 
 
-export async function klektLowestPrice(item, size, currencyRate) {
+export async function klektLowestPrice(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.skuId !== '' ? item.skuId : item.modelName.replace('(W)', '')
-
-	const request = createRequestObject('klekt', {search: search, size: size})
+	const request = createRequestObject('klekt', {
+		search: search, 
+		size: filter.size,
+		ship_to: filter.country
+	})
+	
 	try {
 		const response = await fetch(request.url, request.headers)
 		if (!response.ok) return []
 
 		let itemData = await response.json()
+
+		// TODO: move shipping currency conversion logic to backend
+		const shippingInfo = itemData[0]['shipping']
+		const shippingConversionRate = await currencyConversionRate(shippingInfo['currency'], filter.currency)
+		let shippingPrice = shippingInfo['cost'] * shippingConversionRate
 
 		return [{
 			source: 'klekt',
-			price: Math.round(itemData[0]['price'] * currencyRate),
-			url: new URL(itemData[0]['url'])
+			price: Math.round(itemData[0]['price'] * filter.eurRate),
+			url: new URL(itemData[0]['url']),
+			shippingPrice: shippingPrice
 		}]
 	} catch (e) {
 		return []
@@ -70,22 +98,32 @@ export async function klektLowestPrice(item, size, currencyRate) {
 }
 
 
-export async function goatLowestPrice(item, size, currencyRate) {
+export async function goatLowestPrice(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.skuId !== '' ? item.skuId : item.modelName.replace('(W)', '')
+	const request = createRequestObject('goat', {
+		search: search, 
+		size: filter.size,
+		ship_to: filter.country
+	})
 	
-	const request = createRequestObject('goat', {search: search, size: size})
 	try {
 		const response = await fetch(request.url, request.headers)
 		if (!response.ok) return []
 
 		let itemData = await response.json()
+
+		// TODO: move shipping currency conversion logic to backend
+		const shippingInfo = itemData[0]['shipping']
+		const shippingConversionRate = await currencyConversionRate(shippingInfo['currency'], filter.currency)
+		let shippingPrice = shippingInfo['cost'] * shippingConversionRate
 		
 		return [{
 			source: 'goat',
-			price: Math.round(itemData[0]['price'] * currencyRate),
-			url: new URL(itemData[0]['url'])
+			price: Math.round(itemData[0]['price'] * filter.usdRate),
+			url: new URL(itemData[0]['url']),
+			shippingPrice: shippingPrice
 		}]
 	} catch (e) {
 		return []
@@ -93,23 +131,32 @@ export async function goatLowestPrice(item, size, currencyRate) {
 }
 
 
-export async function flightclubLowestPrice(item, size, gender, currencyRate) {
+export async function flightclubLowestPrice(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.skuId !== '' ? item.skuId : item.modelName.replace('(W)', '')
-	if (gender === 'women') size -= 1.5
-	
-	const request = createRequestObject('flightclub', {search: search, size: size})
+	const request = createRequestObject('flightclub', {
+		search: search, 
+		size: filter.gender === 'women' ? filter.size-1.5 : filter.size,
+		ship_to: filter.country
+	})
+
 	try {
 		const response = await fetch(request.url, request.headers)
 		if (!response.ok) return []
 
 		let itemData = await response.json()
+
+		// TODO: move shipping currency conversion logic to backend
+		const shippingInfo = itemData[0]['shipping']
+		const shippingConversionRate = await currencyConversionRate(shippingInfo['currency'], filter.currency)
+		let shippingPrice = shippingInfo['cost'] * shippingConversionRate
 		
 		return [{
 			source: 'flightclub',
-			price: Math.round(itemData[0]['price'] * currencyRate),
-			url: new URL(itemData[0]['url'])
+			price: Math.round(itemData[0]['price'] * filter.usdRate),
+			url: new URL(itemData[0]['url']),
+			shippingPrice: shippingPrice
 		}]
 	} catch (e) {
 		return []
@@ -117,12 +164,17 @@ export async function flightclubLowestPrice(item, size, gender, currencyRate) {
 }
 
 
-export async function ebayListings(item, size, country, currencyRate, currency, postalCode) {
+export async function ebayListings(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.modelName.replace('(W)', '').concat(' ', item.skuId)
-	const request = createRequestObject('ebay', {search: search, size: size, shipTo: country, postalCode: postalCode})
-	
+	const request = createRequestObject('ebay', {
+		search: search, 
+		size: filter.size, 
+		ship_to: filter.country, 
+		postal_code: filter.postalCode
+	})
+
 	try {
 		const response = await fetch(request.url, request.headers)
 		if (!response.ok) return []
@@ -134,8 +186,8 @@ export async function ebayListings(item, size, country, currencyRate, currency, 
 			// TODO: move shipping currency conversion logic to backend
 			let shipping = null
 			if (item['shipping']) {
-				if (currency !== item['shipping']['@currencyId']) 
-					shipping = Math.round(item['shipping']['__value__'] * currencyRate)
+				if (filter.currency !== item['shipping']['@currencyId']) 
+					shipping = Math.round(item['shipping']['__value__'] * filter.usdRate)
 				else 
 					shipping = Math.round(item['shipping']['__value__'])
 			}
@@ -143,7 +195,7 @@ export async function ebayListings(item, size, country, currencyRate, currency, 
 			results.push({
 				id: item['id'],
 				source: 'ebay',
-				price: Math.round(item['price'] * currencyRate),
+				price: Math.round(item['price'] * filter.usdRate),
 				image: item['image'],
 				url: item['url'],
 				condition: item['condition'],
@@ -157,11 +209,17 @@ export async function ebayListings(item, size, country, currencyRate, currency, 
 }
 
 
-export async function depopListings(item, size, gender, currencyRate, country) {
+export async function depopListings(item, filter) {
 	if (!item.hasPrice) return []
 
 	let search = item.modelName.replace('(W)', '')
-	const request = createRequestObject('depopListings', {search: search, size: size, gender: gender, shipTo: country})
+	const request = createRequestObject('depop', {
+		search: search, 
+		size: filter.size, 
+		gender: filter.gender, 
+		ship_to: filter.country
+	})
+
 	try {
 		const response = await fetch(request.url, request.headers)
 		if (!response.ok) return []
@@ -172,10 +230,10 @@ export async function depopListings(item, size, gender, currencyRate, country) {
 			results.push({
 				id: item['id'],
 				source: 'depop',
-				price: Math.round(item['price'] * currencyRate),
+				price: Math.round(item['price'] * filter.usdRate),
 				image: item['image'],
 				url: new URL(item['url']),
-				shippingPrice: Math.round(item['shipping'] * currencyRate)
+				shippingPrice: Math.round(item['shipping'] * filter.usdRate)
 			})
 		}
 		return results
@@ -184,11 +242,15 @@ export async function depopListings(item, size, gender, currencyRate, country) {
 	}
 }
 
-export async function grailedListings(item, size, currencyRate, country) {
+export async function grailedListings(item, filter) {
 	if (!item.hasPrice) return []
 	
 	let search = item.modelName.replace('(W)', '')
-	const request = createRequestObject('grailedListings', {search: search, size: size, shipTo: country})
+	const request = createRequestObject('grailed', {
+		search: search, 
+		size: filter.size, 
+		ship_to: filter.country
+	})
 
 	try {
 		const response = await fetch(request.url, request.headers)
@@ -201,10 +263,10 @@ export async function grailedListings(item, size, currencyRate, country) {
 			let itemResult = {
 				id: item['id'],
 				source: 'grailed',
-				price: Math.round(item['price'] * currencyRate),
+				price: Math.round(item['price'] * filter.usdRate),
 				image: item['image'],
 				url: new URL(item['url']),
-				shippingPrice: item['shipping'] ? Math.round(item['shipping'] * currencyRate) : null
+				shippingPrice: item['shipping'] ? Math.round(item['shipping'] * filter.usdRate) : null
 			}
 			results.push(itemResult)
 		}


### PR DESCRIPTION
Changes include:
- removing calls to /shippingprices endpoint; shipping info will be in the object returned by /itemprices for stockx, goat, flight club, and klekt now
- general code cleanup: 
  - changed passing individual parameters to the scrapers.js functions to a single 'filter' object
  - filter object passed to createRequestObject will match naming of API parameters (no more object deconstruction)